### PR TITLE
feat: added support for source and derived properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,15 @@ instrumentObject:
     - serialNumber (string)
 ```
 
-- For spectra, there is also the `sourceType` which can be `experiment`, `simulation` or `literature` and `sourceDetails` can be specified with
+- For spectra, there is also the `source` which can be specified with
 
 ```
-sourceDetails (object):
+source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
 ```
 
 - In some cases, there might be derived properties. Those should be grouped under `derivedProperties`

--- a/README.md
+++ b/README.md
@@ -81,4 +81,15 @@ instrumentObject:
     - serialNumber (string)
 ```
 
+- For spectra, there is also the `sourceType` which can be `experiment`, `simulation` or `literature` and `sourceDetails` can be specified with
+
+```
+sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
+```
+
+- In some cases, there might be derived properties. Those should be grouped under `derivedProperties`
+
 - Any new markdown page must be added to the `README.md` file

--- a/schema/sample/spectra/chromatogram.md
+++ b/schema/sample/spectra/chromatogram.md
@@ -1,9 +1,10 @@
 - mass (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - analyzer ("ms,ms/ms,uv,fid")
   - cdf (object):
     - filename

--- a/schema/sample/spectra/chromatogram.md
+++ b/schema/sample/spectra/chromatogram.md
@@ -1,4 +1,9 @@
 - mass (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - analyzer ("ms,ms/ms,uv,fid")
   - cdf (object):
     - filename

--- a/schema/sample/spectra/cyclicVoltammetry.md
+++ b/schema/sample/spectra/cyclicVoltammetry.md
@@ -1,4 +1,9 @@
 - cyclicVoltammetry (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/cyclicVoltammetry.md
+++ b/schema/sample/spectra/cyclicVoltammetry.md
@@ -1,9 +1,10 @@
 - cyclicVoltammetry (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/differentialCentrifugalSedimentation.md
+++ b/schema/sample/spectra/differentialCentrifugalSedimentation.md
@@ -1,4 +1,9 @@
 - differentialCentrifugalSedimentation (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/differentialCentrifugalSedimentation.md
+++ b/schema/sample/spectra/differentialCentrifugalSedimentation.md
@@ -1,9 +1,10 @@
 - differentialCentrifugalSedimentation (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/differentialScanningCalorimetry.md
+++ b/schema/sample/spectra/differentialScanningCalorimetry.md
@@ -1,4 +1,9 @@
 - differentialScanningCalorimetry (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/differentialScanningCalorimetry.md
+++ b/schema/sample/spectra/differentialScanningCalorimetry.md
@@ -1,9 +1,10 @@
 - differentialScanningCalorimetry (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/elementalAnalysis.md
+++ b/schema/sample/spectra/elementalAnalysis.md
@@ -1,9 +1,10 @@
 - elementalAnalysis
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - c (number)
   - h (number)
   - instrument (object):

--- a/schema/sample/spectra/elementalAnalysis.md
+++ b/schema/sample/spectra/elementalAnalysis.md
@@ -1,4 +1,9 @@
 - elementalAnalysis
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - c (number)
   - h (number)
   - instrument (object):

--- a/schema/sample/spectra/flowCytometry.md
+++ b/schema/sample/spectra/flowCytometry.md
@@ -1,9 +1,10 @@
 - flowCytometry (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/flowCytometry.md
+++ b/schema/sample/spectra/flowCytometry.md
@@ -1,4 +1,9 @@
 - flowCytometry (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/hgPorosimetry.md
+++ b/schema/sample/spectra/hgPorosimetry.md
@@ -1,4 +1,9 @@
 - hgPorosimetry (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/hgPorosimetry.md
+++ b/schema/sample/spectra/hgPorosimetry.md
@@ -1,9 +1,10 @@
 - hgPorosimetry (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/ir.md
+++ b/schema/sample/spectra/ir.md
@@ -1,4 +1,10 @@
 - ir (array<object>):
+  - source (object):
+    - type (experiment|simulation|literature)
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
+    - doi (str)
+    - url (str)
   - conditions (string): For example, grinded in KBr
   - description (html)
   - experiment (string): For example, XRD

--- a/schema/sample/spectra/isotherm.md
+++ b/schema/sample/spectra/isotherm.md
@@ -1,9 +1,10 @@
 - isotherm (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/isotherm.md
+++ b/schema/sample/spectra/isotherm.md
@@ -1,4 +1,9 @@
 - isotherm (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)
@@ -12,10 +17,16 @@
   - sampleWeight (number, g)
   - temperature (number, K)
   - gas (array<string>): possible values: "CO2,CH4,H2O,H2,N2,Xe,He"
-  - specificPoreVolume (object):
-    - SI (number)
-    - unit (string): cm^3/g
-  - specificSurfaceArea (object):
-    - SI (number)
-    - unit (string): m^2/g
-  - temperature (number, K)
+  - derivedProperties (object)
+    - specificPoreVolume (object):
+      - SI (number)
+      - unit (string): cm^3/g
+    - henryCoefficient (object):
+      - SI (number)
+      - unit (string): mol/kg/Pa
+    - henryCoefficientDev (object):
+      - SI (number)
+      - unit (string): mol/kg/Pa
+    - saturationLoading (object):
+      - SI (number)
+      - unit (string): mol/kg

--- a/schema/sample/spectra/iv.md
+++ b/schema/sample/spectra/iv.md
@@ -1,4 +1,9 @@
 - iv (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - experiment (string)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/iv.md
+++ b/schema/sample/spectra/iv.md
@@ -1,9 +1,10 @@
 - iv (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - experiment (string)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/mass.md
+++ b/schema/sample/spectra/mass.md
@@ -1,9 +1,10 @@
 - mass (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - accurate (object):
     - mf (string)
     - modification (string)

--- a/schema/sample/spectra/mass.md
+++ b/schema/sample/spectra/mass.md
@@ -1,4 +1,9 @@
 - mass (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - accurate (object):
     - mf (string)
     - modification (string)

--- a/schema/sample/spectra/nmr.md
+++ b/schema/sample/spectra/nmr.md
@@ -1,84 +1,85 @@
 - nmr (array<object>):
-- sourceType (experiment|simulation|literature)
-- sourceDetails (object):
-  - name (str): e.g., aiidalab.materialscloud.org
-  - uuid (str)
-  - doi (str)
-- concentration (number, mol/L)
-- date (string): Date and time expressed according to ISO 8601
-- description (html)
-- dimension (int): nucleus.length()
-- environment (string): For example, CO2
-- experiment ("1d,hsqc,hmbc,hmqc,jres,cosy,tocsy,hsqtocsy,noesy,roesy,dept,aptjmod")
-- frequency (number, MHz)
-- instrument (object):
-  - manufacturer (string)
-  - model (string)
-  - serialNumber (string)
-  - software (string)
-- isFID (bool)
-- isFT (bool)
-- jcamp (object):
-  - filename (string)
-- jcampFID (object):
-  - filename (string)
-- nucleus (array<string>): For example, [1H]
-- pdf (object):
-  - filename (string)
-- probe (string)
-- pulse (string): For example "<zg>"
-- range (array<object>): Describes the integrated range
-  - dimension (int): if this range was assigned from a nD n>1, otherwise this attribute should not exist
-  - from (number)
-  - integral (number)
-  - pubIntegral (number): published integral
-  - signal (array<object>):
-    - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
-    - j (array<object>):
-      - coupling (number, Hz)
+  - source (object):
+    - type (experiment|simulation|literature)
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
+    - doi (str)
+    - url (str)
+  - concentration (number, mol/L)
+  - date (string): Date and time expressed according to ISO 8601
+  - description (html)
+  - dimension (int): nucleus.length()
+  - environment (string): For example, CO2
+  - experiment ("1d,hsqc,hmbc,hmqc,jres,cosy,tocsy,hsqtocsy,noesy,roesy,dept,aptjmod")
+  - frequency (number, MHz)
+  - instrument (object):
+    - manufacturer (string)
+    - model (string)
+    - serialNumber (string)
+    - software (string)
+  - isFID (bool)
+  - isFT (bool)
+  - jcamp (object):
+    - filename (string)
+  - jcampFID (object):
+    - filename (string)
+  - nucleus (array<string>): For example, [1H]
+  - pdf (object):
+    - filename (string)
+  - probe (string)
+  - pulse (string): For example "<zg>"
+  - range (array<object>): Describes the integrated range
+    - dimension (int): if this range was assigned from a nD n>1, otherwise this attribute should not exist
+    - from (number)
+    - integral (number)
+    - pubIntegral (number): published integral
+    - signal (array<object>):
       - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
-      - distance ()
-      - multiplicity("d,t,q,p,pent,quint,sext,hex,sept,hept,oct,non"): p = pent = quint, sext = hex, sept=hept
-    - kind ("solvent,impurity,reference,standard,P1,P2,P3"): By default empty and a real assignment. For integration "solvent", "reference", "impurity" and "standard" do not count.
-    - nbAtoms (int)
-    - peak (array<object>):
-      - width (number, Hz)
-      - x (number, ppm): chemical shift
-      - y (number): relative height
-    - assignment (string)
-    - multiplicity (string)
-    - delta (number): chemical shift in ppm
-    - pubAssignment (string): published assignment (if different from assignment)
-    - pubMultiplicity (string): published multiplicity (if different from multiplicity)
-    - relability (number, %): Between 0 and 100, used for automatic assignment
-    - remarks (HTML)
-    - statistics (object): Used when predicting for HOSE code database
-      - average (number)
-      - max (number)
-      - min (number)
-      - std (number)
-  - to (number)
-- reference (string): For example, TMS
-- report (object): HTML file with analytical report
-  - filename
-- solvent (string)
-- spinningFrequency (number, kHz)
-- temperature (number, K)
-- zip (object):
-  - filename
-- zone (array<object>): used for 2D NMR
-  - integral (number)
-  - x (object):
-    - from (number)
+      - j (array<object>):
+        - coupling (number, Hz)
+        - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
+        - distance ()
+        - multiplicity("d,t,q,p,pent,quint,sext,hex,sept,hept,oct,non"): p = pent = quint, sext = hex, sept=hept
+      - kind ("solvent,impurity,reference,standard,P1,P2,P3"): By default empty and a real assignment. For integration "solvent", "reference", "impurity" and "standard" do not count.
+      - nbAtoms (int)
+      - peak (array<object>):
+        - width (number, Hz)
+        - x (number, ppm): chemical shift
+        - y (number): relative height
+      - assignment (string)
+      - multiplicity (string)
+      - delta (number): chemical shift in ppm
+      - pubAssignment (string): published assignment (if different from assignment)
+      - pubMultiplicity (string): published multiplicity (if different from multiplicity)
+      - relability (number, %): Between 0 and 100, used for automatic assignment
+      - remarks (HTML)
+      - statistics (object): Used when predicting for HOSE code database
+        - average (number)
+        - max (number)
+        - min (number)
+        - std (number)
     - to (number)
-  - y (object):
-    - from (number)
-    - to (number)
-  - signal (array<object>):
-    - peak (array<object>):
+  - reference (string): For example, TMS
+  - report (object): HTML file with analytical report
+    - filename
+  - solvent (string)
+  - spinningFrequency (number, kHz)
+  - temperature (number, K)
+  - zip (object):
+    - filename
+  - zone (array<object>): used for 2D NMR
+    - integral (number)
     - x (object):
-      - delta (number)
-      - diaID (array)
-    - y (object)
-      - delta (number)
-      - diaID (array)
+      - from (number)
+      - to (number)
+    - y (object):
+      - from (number)
+      - to (number)
+    - signal (array<object>):
+      - peak (array<object>):
+      - x (object):
+        - delta (number)
+        - diaID (array)
+      - y (object)
+        - delta (number)
+        - diaID (array)

--- a/schema/sample/spectra/nmr.md
+++ b/schema/sample/spectra/nmr.md
@@ -1,80 +1,84 @@
 - nmr (array<object>):
-  - concentration (number, mol/L)
-  - date (string): Date and time expressed according to ISO 8601
-  - description (html)
-  - dimension (int): nucleus.length()
-  - environment (string): For example, CO2
-  - experiment ("1d,hsqc,hmbc,hmqc,jres,cosy,tocsy,hsqtocsy,noesy,roesy,dept,aptjmod")
-  - frequency (number, MHz)
-  - instrument (object):
-    - manufacturer (string)
-    - model (string)
-    - serialNumber (string)
-    - software (string)
-  - isFID (bool)
-  - isFT (bool)
-  - jcamp (object):
-    - filename (string)
-  - jcampFID (object):
-    - filename (string)
-  - nucleus (array<string>): For example, [1H]
-  - pdf (object):
-    - filename (string)
-  - probe (string)
-  - pulse (string): For example "<zg>"
-  - range (array<object>): Describes the integrated range
-    - dimension (int): if this range was assigned from a nD n>1, otherwise this attribute should not exist
-    - from (number)
-    - integral (number)
-    - pubIntegral (number): published integral
-    - signal (array<object>):
+- sourceType (experiment|simulation|literature)
+- sourceDetails (object):
+  - name (str): e.g., aiidalab.materialscloud.org
+  - uuid (str)
+  - doi (str)
+- concentration (number, mol/L)
+- date (string): Date and time expressed according to ISO 8601
+- description (html)
+- dimension (int): nucleus.length()
+- environment (string): For example, CO2
+- experiment ("1d,hsqc,hmbc,hmqc,jres,cosy,tocsy,hsqtocsy,noesy,roesy,dept,aptjmod")
+- frequency (number, MHz)
+- instrument (object):
+  - manufacturer (string)
+  - model (string)
+  - serialNumber (string)
+  - software (string)
+- isFID (bool)
+- isFT (bool)
+- jcamp (object):
+  - filename (string)
+- jcampFID (object):
+  - filename (string)
+- nucleus (array<string>): For example, [1H]
+- pdf (object):
+  - filename (string)
+- probe (string)
+- pulse (string): For example "<zg>"
+- range (array<object>): Describes the integrated range
+  - dimension (int): if this range was assigned from a nD n>1, otherwise this attribute should not exist
+  - from (number)
+  - integral (number)
+  - pubIntegral (number): published integral
+  - signal (array<object>):
+    - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
+    - j (array<object>):
+      - coupling (number, Hz)
       - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
-      - j (array<object>):
-        - coupling (number, Hz)
-        - diaID (array): [Diasterotopic ID](http://www.cheminfo.org/?viewURL=https%3A%2F%2Fcouch.cheminfo.org%2Fcheminfo-public%2F45874b6300d148da891252f6263c62ae%2Fview.json&loadversion=true&fillsearch=Diastereotopic+IDs)
-        - distance ()
-        - multiplicity("d,t,q,p,pent,quint,sext,hex,sept,hept,oct,non"): p = pent = quint, sext = hex, sept=hept
-      - kind ("solvent,impurity,reference,standard,P1,P2,P3"): By default empty and a real assignment. For integration "solvent", "reference", "impurity" and "standard" do not count.
-      - nbAtoms (int)
-      - peak (array<object>):
-        - width (number, Hz)
-        - x (number, ppm): chemical shift
-        - y (number): relative height
-      - assignment (string)
-      - multiplicity (string)
-      - delta (number): chemical shift in ppm
-      - pubAssignment (string): published assignment (if different from assignment)
-      - pubMultiplicity (string): published multiplicity (if different from multiplicity)
-      - relability (number, %): Between 0 and 100, used for automatic assignment
-      - remarks (HTML)
-      - statistics (object): Used when predicting for HOSE code database
-        - average (number)
-        - max (number)
-        - min (number)
-        - std (number)
+      - distance ()
+      - multiplicity("d,t,q,p,pent,quint,sext,hex,sept,hept,oct,non"): p = pent = quint, sext = hex, sept=hept
+    - kind ("solvent,impurity,reference,standard,P1,P2,P3"): By default empty and a real assignment. For integration "solvent", "reference", "impurity" and "standard" do not count.
+    - nbAtoms (int)
+    - peak (array<object>):
+      - width (number, Hz)
+      - x (number, ppm): chemical shift
+      - y (number): relative height
+    - assignment (string)
+    - multiplicity (string)
+    - delta (number): chemical shift in ppm
+    - pubAssignment (string): published assignment (if different from assignment)
+    - pubMultiplicity (string): published multiplicity (if different from multiplicity)
+    - relability (number, %): Between 0 and 100, used for automatic assignment
+    - remarks (HTML)
+    - statistics (object): Used when predicting for HOSE code database
+      - average (number)
+      - max (number)
+      - min (number)
+      - std (number)
+  - to (number)
+- reference (string): For example, TMS
+- report (object): HTML file with analytical report
+  - filename
+- solvent (string)
+- spinningFrequency (number, kHz)
+- temperature (number, K)
+- zip (object):
+  - filename
+- zone (array<object>): used for 2D NMR
+  - integral (number)
+  - x (object):
+    - from (number)
     - to (number)
-  - reference (string): For example, TMS
-  - report (object): HTML file with analytical report
-    - filename
-  - solvent (string)
-  - spinningFrequency (number, kHz)
-  - temperature (number, K)
-  - zip (object):
-    - filename
-  - zone (array<object>): used for 2D NMR
-    - integral (number)
+  - y (object):
+    - from (number)
+    - to (number)
+  - signal (array<object>):
+    - peak (array<object>):
     - x (object):
-      - from (number)
-      - to (number)
-    - y (object):
-      - from (number)
-      - to (number)
-    - signal (array<object>):
-      - peak (array<object>):
-      - x (object):
-        - delta (number)
-        - diaID (array)
-      - y (object)
-        - delta (number)
-        - diaID (array)
-
+      - delta (number)
+      - diaID (array)
+    - y (object)
+      - delta (number)
+      - diaID (array)

--- a/schema/sample/spectra/raman.md
+++ b/schema/sample/spectra/raman.md
@@ -1,23 +1,24 @@
 - raman (array<object>):
-- sourceType (experiment|simulation|literature)
-- sourceDetails (object):
-  - name (str): e.g., aiidalab.materialscloud.org
-  - uuid (str)
-  - doi (str)
-- description (html)
-- excitationWavelength (number, nm)
-- experiment (string)
-- instrument (object):
-  - manufacturer (string)
-  - model (string)
-  - serialNumber (string)
-  - software (string)
-- jcamp (object)
-- misc (object)
-- peak (array<object>):
-  - assignment (string)
-  - kind ("s,m,w"): strong, medium, weak
-  - wavelength (number, cm-1): Actually the wavenumber
-- procedure (html)
-- remarks (html)
-- substrate (string): Element symbol like Ag
+  - source (object):
+    - type (experiment|simulation|literature)
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
+    - doi (str)
+    - url (str)
+  - description (html)
+  - excitationWavelength (number, nm)
+  - experiment (string)
+  - instrument (object):
+    - manufacturer (string)
+    - model (string)
+    - serialNumber (string)
+    - software (string)
+  - jcamp (object)
+  - misc (object)
+  - peak (array<object>):
+    - assignment (string)
+    - kind ("s,m,w"): strong, medium, weak
+    - wavelength (number, cm-1): Actually the wavenumber
+  - procedure (html)
+  - remarks (html)
+  - substrate (string): Element symbol like Ag

--- a/schema/sample/spectra/raman.md
+++ b/schema/sample/spectra/raman.md
@@ -1,18 +1,23 @@
 - raman (array<object>):
-  - description (html)
-  - excitationWavelength (number, nm)
-  - experiment (string)
-  - instrument (object):
-    - manufacturer (string)
-    - model (string)
-    - serialNumber (string)
-    - software (string)
-  - jcamp (object)
-  - misc (object)
-  - peak (array<object>):
-    - assignment (string)
-    - kind ("s,m,w"): strong, medium, weak
-    - wavelength (number, cm-1): Actually the wavenumber
-  - procedure (html)
-  - remarks (html)
-  - substrate (string): Element symbol like Ag
+- sourceType (experiment|simulation|literature)
+- sourceDetails (object):
+  - name (str): e.g., aiidalab.materialscloud.org
+  - uuid (str)
+  - doi (str)
+- description (html)
+- excitationWavelength (number, nm)
+- experiment (string)
+- instrument (object):
+  - manufacturer (string)
+  - model (string)
+  - serialNumber (string)
+  - software (string)
+- jcamp (object)
+- misc (object)
+- peak (array<object>):
+  - assignment (string)
+  - kind ("s,m,w"): strong, medium, weak
+  - wavelength (number, cm-1): Actually the wavenumber
+- procedure (html)
+- remarks (html)
+- substrate (string): Element symbol like Ag

--- a/schema/sample/spectra/thermogravimetricAnalysis.md
+++ b/schema/sample/spectra/thermogravimetricAnalysis.md
@@ -1,4 +1,9 @@
 - thermogravimetricAnalysis (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/thermogravimetricAnalysis.md
+++ b/schema/sample/spectra/thermogravimetricAnalysis.md
@@ -1,9 +1,10 @@
 - thermogravimetricAnalysis (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - description (html)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/uv.md
+++ b/schema/sample/spectra/uv.md
@@ -1,9 +1,10 @@
 - uv (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - conditions
   - description (html)
   - experiment (string)

--- a/schema/sample/spectra/uv.md
+++ b/schema/sample/spectra/uv.md
@@ -1,4 +1,9 @@
 - uv (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - conditions
   - description (html)
   - experiment (string)

--- a/schema/sample/spectra/xps.md
+++ b/schema/sample/spectra/xps.md
@@ -1,4 +1,9 @@
 - xps (array<object>): x-ray photoelectron spectroscopy
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - experiment (string)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/xps.md
+++ b/schema/sample/spectra/xps.md
@@ -1,9 +1,10 @@
 - xps (array<object>): x-ray photoelectron spectroscopy
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - experiment (string)
   - instrument (object):
     - manufacturer (string)

--- a/schema/sample/spectra/xray.md
+++ b/schema/sample/spectra/xray.md
@@ -1,9 +1,10 @@
 - xray (array<object>):
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - cif (object):
     - filename (string)
   - pdb (object):

--- a/schema/sample/spectra/xray.md
+++ b/schema/sample/spectra/xray.md
@@ -1,7 +1,24 @@
 - xray (array<object>):
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - cif (object):
     - filename (string)
   - pdb (object):
     - filename (string)
-  - rscrCode (string): for example, dia
+  - rscrCode (object): for example, dia
   - temperature (number, K)
+  - derivedProperties (object)
+    - poreProperties:
+      - sourceType (str)
+      - simulationDetails (object):
+        - engine (str): e.g., aiidalab.materialscloud.org
+        - uuid (str): uuid of the data object in the simulation engine
+      - poreAccessibleVolumeFraction (object):
+        - SI (number)
+        - unit (string): 1/A^3
+      - specificporeAccessibleVolume (object):
+        - SI (number)
+        - unit (string): cm^3/g

--- a/schema/sample/spectra/xray.md
+++ b/schema/sample/spectra/xray.md
@@ -13,10 +13,12 @@
   - temperature (number, K)
   - derivedProperties (object)
     - poreProperties:
-      - sourceType (str)
-      - simulationDetails (object):
-        - engine (str): e.g., aiidalab.materialscloud.org
-        - uuid (str): uuid of the data object in the simulation engine
+      - source (object):
+        - type (experiment|simulation|literature)
+        - name (str): e.g., aiidalab.materialscloud.org
+        - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
+        - doi (str)
+        - url (str)
       - poreAccessibleVolumeFraction (object):
         - SI (number)
         - unit (string): 1/A^3

--- a/schema/sample/spectra/xrd.md
+++ b/schema/sample/spectra/xrd.md
@@ -1,9 +1,10 @@
 - xrd (array<object>): Powder x-ray diffraction:
-  - sourceType (experiment|simulation|literature)
-  - sourceDetails (object):
+  - source (object):
+    - type (experiment|simulation|literature)
     - name (str): e.g., aiidalab.materialscloud.org
-    - uuid (str)
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
     - doi (str)
+    - url (str)
   - anode ("CuKa,CuKa2,CuKa1,CuKb1,MoKa,MoKa2,MoKa1,MoKb1,CrKa,CrKa2,CrKa1,CrKb1,FeKa,FeKa2,FeKa1,FeKb1,CoKa,CoKa1,CoKa2,CoKb1,AgKa,AgKa1,AgKa2,AgKb1")
   - environment (string): For example, in vacuo, N2
   - instrument (object):

--- a/schema/sample/spectra/xrd.md
+++ b/schema/sample/spectra/xrd.md
@@ -1,4 +1,9 @@
 - xrd (array<object>): Powder x-ray diffraction:
+  - sourceType (experiment|simulation|literature)
+  - sourceDetails (object):
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str)
+    - doi (str)
   - anode ("CuKa,CuKa2,CuKa1,CuKb1,MoKa,MoKa2,MoKa1,MoKb1,CrKa,CrKa2,CrKa1,CrKb1,FeKa,FeKa2,FeKa1,FeKb1,CoKa,CoKa1,CoKa2,CoKb1,AgKa,AgKa1,AgKa2,AgKb1")
   - environment (string): For example, in vacuo, N2
   - instrument (object):

--- a/schema/sample/spectra/xrf.md
+++ b/schema/sample/spectra/xrf.md
@@ -1,4 +1,10 @@
 - xrf (array<object>): x-ray fluorescence spectroscopy
+  - source (object):
+    - type (experiment|simulation|literature)
+    - name (str): e.g., aiidalab.materialscloud.org
+    - uuid (str): e.g., the UUID of the node of the object in AiiDAlab or the UUID of the data in some other database
+    - doi (str)
+    - url (str)
   - experiment (string)
   - instrument (object):
     - manufacturer (string)


### PR DESCRIPTION
the idea is that for some analysis we might have more complex derived data (that is, more than just peak picking/operation on the spectra) some examples might be pore analysis using codes like zeo++ or isotherm fitting which then leads to henry-coefficient ... 

also this PR adds support for `sourceType` and `sourceDetails` such that we can indicate if a piece of data was imported from the literature (some users might use a CIF from the literature) or some simulation (our integration with AiiDAlab)